### PR TITLE
Refactor DB backup support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ nano server_list.json
       "port": 22,
       "user": "user",
       "pass": "pass",
-      "is_mysql_DB": false, 
-      "mysql_user": "root",
-      "mysql_password": "password",
+      "db_type": "mysql",
+      "db_user": "root",
+      "db_password": "password",
       "database_name": "marzban",
-      "mysql_contaner_name": "marzban-mysql-1",
+      "db_contaner_name": "marzban-mysql-1",
       "exclude": [
         "mysql"
       ],
@@ -62,7 +62,7 @@ nano server_list.json
 }
 ```
 
-if you use **mysql** database for your pannel set `"is_mysql_DB"` flag `true`
+set `db_type` to `mysql` or `mariadb` to enable database backup
 
 if you don't want get backup of some folders or files use `exclude` list
 
@@ -76,11 +76,11 @@ bot support multiple panel if you have another panel you can use this json
       "port": 22,
       "user": "user",
       "pass": "pass",
-      "is_mysql_DB": false, 
-      "mysql_user": "root",
-      "mysql_password": "password",
+      "db_type": "mariadb",
+      "db_user": "root",
+      "db_password": "password",
       "database_name": "marzban",
-      "mysql_contaner_name": "marzban-mysql-1",
+      "db_contaner_name": "marzban-mysql-1",
       "exclude": [
         "mysql"
       ],
@@ -92,11 +92,11 @@ bot support multiple panel if you have another panel you can use this json
       "port": 22,
       "user": "user2",
       "pass": "pass2",
-      "is_mysql_DB": true, 
-      "mysql_user": "root",
-      "mysql_password": "password",
+      "db_type": "mysql",
+      "db_user": "root",
+      "db_password": "password",
       "database_name": "marzban",
-      "mysql_contaner_name": "marzban-mysql-1",
+      "db_contaner_name": "marzban-mysql-1",
       "exclude": [
         "mysql"
       ],

--- a/server_list.json.example
+++ b/server_list.json.example
@@ -5,11 +5,11 @@
       "port": 22,
       "user": "user",
       "pass": "pass",
-      "is_mysql_DB": false, 
-      "mysql_user": "root",
-      "mysql_password": "password",
+      "db_type": "mysql",
+      "db_user": "root",
+      "db_password": "password",
       "database_name": "marzban",
-      "mysql_contaner_name": "marzban-mysql-1",
+      "db_contaner_name": "marzban-mysql-1",
       "exclude": [
         "mysql"
       ],


### PR DESCRIPTION
## Summary
- add generic `db_backup` to handle MySQL or MariaDB
- update `create_zipFile` to use `db_type`
- update `send_full_backups` to read `db_type` with backwards compatibility
- rename DB related variables to generic names
- update documentation and examples for new `db_type` parameter

## Testing
- `python3 -m py_compile main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68523c7afb04832bab3cf1ed48f4a955